### PR TITLE
Add tests to test the filtering of search results using sliders.

### DIFF
--- a/pages/search_page.py
+++ b/pages/search_page.py
@@ -19,7 +19,7 @@
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s): Zac Campbell
-#                 
+#
 #
 # Alternatively, the contents of this file may be used under the terms of
 # either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -38,48 +38,53 @@ from pages.base_page import FlightDeckBasePage
 from page import Page
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
 
 
 class SearchPage(FlightDeckBasePage):
 
     _search_field_locator = (By.CSS_SELECTOR, "#Search input[type='search']")
     _search_button_locator = (By.CSS_SELECTOR, "#Search button[type='submit']")
-    
+
     _filter_by_addons_locator = (By.LINK_TEXT, "Add-ons")
     _filter_by_libraries_locator = (By.LINK_TEXT, "Libraries")
-    
+
     _addon_count_label_locator = (By.XPATH, "//strong[preceding-sibling::a[contains(text(),'Add-ons')]]")
     _library_count_label_locator = (By.XPATH, "//strong[preceding-sibling::a[contains(text(),'Libraries')]]")
-    
+
+    _copies_knob_locator = (By.CSS_SELECTOR, "#CopiesFilter div.knob")
+    _used_knob_locator = (By.CSS_SELECTOR, "#UsedFilter div.knob")
+    _activity_knob_locator = (By.CSS_SELECTOR, "#ActivityFilter div.knob")
+
     _results_message_locator = (By.CSS_SELECTOR, "#SearchResults > p")
-    
+
     def addon(self, lookup):
         return self.Addon(self.testsetup, lookup)
-        
+
     def library(self, lookup):
-        return self.Library(self.testsetup, lookup)        
-    
+        return self.Library(self.testsetup, lookup)
+
     def _item_locator_by_name(self, name):
         return (By.LINK_TEXT, name)
-    
+
     def type_search_term(self, text):
         self.selenium.find_element(*self._search_field_locator).send_keys(text)
-    
+
     def clear_search(self):
         self.selenium.find_element(*self._search_field_locator).clear()
-    
+
     def click_search(self):
         self.selenium.find_element(*self._search_button_locator).click()
-        
+
     def click_filter_addons_link(self):
         self.selenium.find_element(*self._filter_by_addons_locator).click()
-        
+
     def click_filter_libraries_link(self):
         self.selenium.find_element(*self._filter_by_libraries_locator).click()
-        
+
     def addons_element_count(self):
         return len(self.selenium.find_elements(*self.Addon._base_locator))
-    
+
     @property
     def addons_count_label(self):
         label = self.selenium.find_element(*self._addon_count_label_locator).text
@@ -92,24 +97,42 @@ class SearchPage(FlightDeckBasePage):
     def library_count_label(self):
         label = self.selenium.find_element(*self._library_count_label_locator).text
         return int(label.strip('()'))
-        
+
+    def move_copies_slider(self, notches):
+        # 33 is the amount of pixels to move one notch
+        x_offset = 33 * notches
+        copies_knob = self.selenium.find_element(*self._copies_knob_locator)
+        ActionChains(self.selenium).drag_and_drop_by_offset(copies_knob, x_offset, 0).perform()
+
+    def move_used_packages_slider(self, notches):
+        # 8 is the amount of pixels to move one notch
+        x_offset = 8 * notches
+        used_packages_knob = self.selenium.find_element(*self._used_knob_locator)
+        ActionChains(self.selenium).drag_and_drop_by_offset(used_packages_knob, x_offset, 0).perform()
+
+    def move_activity_slider(self, notches):
+        # 38 is the amount of pixels to move one notch
+        x_offset = 38 * notches
+        activity_knob = self.selenium.find_element(*self._activity_knob_locator)
+        ActionChains(self.selenium).drag_and_drop_by_offset(activity_knob, x_offset, 0).perform()
+
     class SearchResultsRegion(Page):
-        
+
         def __init__(self, testsetup, lookup):
             Page.__init__(self, testsetup)
             if type(lookup) is int:
                 self._root_locator = (self._base_locator[0], "%s[%i]" % (self._base_locator[1], lookup))
             elif type(lookup) is unicode:
                 self._root_locator = (self._base_locator[0], "%s[descendant::h3/a[text()='%s']]" % (self._base_locator[1], lookup))
-         
+
         _name_locator = (By.CSS_SELECTOR, "h3 > a")
         _author_link_locator = (By.CSS_SELECTOR, "h3 > span > a")
-        _source_locator = (By.CSS_SELECTOR, "li.UI_Edit_Version > a")   
-     
+        _source_locator = (By.CSS_SELECTOR, "li.UI_Edit_Version > a")
+
         @property
         def root_element(self):
             return self.selenium.find_element(*self._root_locator)
-              
+
         def is_displayed(self):
             return self.is_element_visible(self._root_locator)
 
@@ -126,15 +149,15 @@ class SearchPage(FlightDeckBasePage):
 
         def click_author(self):
             self.root_element.find_element(*self._author_link_locator).click()
-           
+
     class Addon(SearchResultsRegion):
-     
+
         _base_locator = (By.XPATH, "//div[contains(@class,'addon')]")
-        _test_btn = (By.CSS_SELECTOR, "li.UI_Try_in_Browser > a")  
-        
+        _test_btn = (By.CSS_SELECTOR, "li.UI_Try_in_Browser > a")
+
         def click_test(self):
             self.root_element.find_element(*self._test_btn).click()
-        
+
     class Library(SearchResultsRegion):
-    
+
         _base_locator = (By.XPATH, "//div[contains(@class,'library')]")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -278,3 +278,47 @@ class TestSearch():
         Assert.equal(editorpage_obj.library_name, library_name)
 
         searchpage_obj.delete_test_data()
+
+    @prod
+    def test_copies_slider_filters_results(self, mozwebqa):
+        homepage_obj = HomePage(mozwebqa)
+        searchpage_obj = SearchPage(mozwebqa)
+
+        homepage_obj.go_to_home_page()
+        homepage_obj.header.click_search()
+
+        initial_addon_count = searchpage_obj.addons_count_label
+        initial_library_count = searchpage_obj.library_count_label
+        searchpage_obj.move_copies_slider(1)
+
+        Assert.true(initial_addon_count > searchpage_obj.addons_count_label)
+        Assert.true(initial_library_count > searchpage_obj.library_count_label)
+
+    @prod
+    def test_used_packages_slider_filters_results(self, mozwebqa):
+        homepage_obj = HomePage(mozwebqa)
+        searchpage_obj = SearchPage(mozwebqa)
+
+        homepage_obj.go_to_home_page()
+        homepage_obj.header.click_search()
+        searchpage_obj.click_filter_libraries_link()
+
+        initial_library_count = searchpage_obj.library_count_label
+        searchpage_obj.move_used_packages_slider(10)
+
+        Assert.true(initial_library_count > searchpage_obj.library_count_label)
+
+    @prod
+    def test_activity_slider_filters_results(self, mozwebqa):
+        homepage_obj = HomePage(mozwebqa)
+        searchpage_obj = SearchPage(mozwebqa)
+
+        homepage_obj.go_to_home_page()
+        homepage_obj.header.click_search()
+
+        initial_addon_count = searchpage_obj.addons_count_label
+        initial_library_count = searchpage_obj.library_count_label
+        searchpage_obj.move_activity_slider(1)
+
+        Assert.true(initial_addon_count > searchpage_obj.addons_count_label)
+        Assert.true(initial_library_count > searchpage_obj.library_count_label)


### PR DESCRIPTION
Search tests move the slider to increase filtering and check that the results have become filtered (less results present).

These may not work on linux due to default profile not allowing the Selenium action chains to work.
