### PR TITLE
Explicit wait for package save spinner to complete

### DIFF
--- a/pages/addon_editor_page.py
+++ b/pages/addon_editor_page.py
@@ -38,6 +38,7 @@ from pages.base_page import FlightDeckBasePage
 from pages.regions.editor_tab_region import EditorTabRegion
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 class AddonEditorPage(FlightDeckBasePage):
@@ -45,6 +46,7 @@ class AddonEditorPage(FlightDeckBasePage):
     _addon_name = (By.ID, 'package-info-name')
     _copy_locator = (By.ID, 'package-copy')
     _save_locator = (By.ID, 'package-save')
+    _save_spinner_locator = (By.CSS_SELECTOR, '#package-save.loading')
     _version_locator = (By.ID, 'version_name')
 
     @property
@@ -57,6 +59,7 @@ class AddonEditorPage(FlightDeckBasePage):
 
     def click_save(self):
         self.selenium.find_element(*self._save_locator).click()
+        WebDriverWait(self.selenium, 10).until(lambda s: not self.is_element_present(*self._save_spinner_locator))
 
     def type_addon_version(self, version_label):
         save_button = self.selenium.find_element(*self._save_locator)

--- a/pages/library_editor_page.py
+++ b/pages/library_editor_page.py
@@ -38,6 +38,7 @@ from pages.base_page import FlightDeckBasePage
 from pages.regions.editor_tab_region import EditorTabRegion
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 class LibraryEditorPage(FlightDeckBasePage):
@@ -45,6 +46,7 @@ class LibraryEditorPage(FlightDeckBasePage):
     _library_name = (By.ID, 'package-info-name')
     _copy_locator = (By.ID, 'package-copy')
     _save_locator = (By.ID, 'package-save')
+    _save_spinner_locator = (By.CSS_SELECTOR, '#package-save.loading')
     _version_locator = (By.ID, 'version_name')
 
     @property
@@ -57,6 +59,7 @@ class LibraryEditorPage(FlightDeckBasePage):
 
     def click_save(self):
         self.selenium.find_element(*self._save_locator).click()
+        WebDriverWait(self.selenium, 10).until(lambda s: not self.is_element_present(*self._save_spinner_locator))
 
     def type_library_version(self, version_label):
         save_button = self.selenium.find_element(*self._save_locator)


### PR DESCRIPTION
UI bug raised ( https://bugzilla.mozilla.org/show_bug.cgi?id=719395 ) but explicit wait was still necessary for the automated testing.
