### PR TITLE
Place space between license and first import

### DIFF
--- a/page.py
+++ b/page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from unittestzero import Assert
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException

--- a/pages/addon_editor_page.py
+++ b/pages/addon_editor_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.base_page import FlightDeckBasePage
 from pages.regions.editor_tab_region import EditorTabRegion
 from selenium.webdriver.common.by import By

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from page import Page
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains

--- a/pages/browser_id.py
+++ b/pages/browser_id.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/pages/dashboard_page.py
+++ b/pages/dashboard_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.base_page import FlightDeckBasePage
 from page import Page
 from selenium.webdriver.common.by import By

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.base_page import FlightDeckBasePage
 from selenium.webdriver.common.by import By
 

--- a/pages/library_editor_page.py
+++ b/pages/library_editor_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.base_page import FlightDeckBasePage
 from pages.regions.editor_tab_region import EditorTabRegion
 from selenium.webdriver.common.by import By

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 

--- a/pages/search_page.py
+++ b/pages/search_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import time
 from page import Page
 from pages.base_page import FlightDeckBasePage

--- a/pages/user_page.py
+++ b/pages/user_page.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.base_page import FlightDeckBasePage
 from selenium.webdriver.common.by import By
 

--- a/tests/test_addon_count.py
+++ b/tests/test_addon_count.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage

--- a/tests/test_addon_create.py
+++ b/tests/test_addon_create.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -3,6 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.dashboard_page import DashboardPage
 from unittestzero import Assert

--- a/tests/test_library_create.py
+++ b/tests/test_library_create.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage

--- a/tests/test_login_logout.py
+++ b/tests/test_login_logout.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage

--- a/tests/test_package_activate.py
+++ b/tests/test_package_activate.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage

--- a/tests/test_package_delete.py
+++ b/tests/test_package_delete.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.login_page import LoginPage
 from pages.search_page import SearchPage

--- a/tests/test_view_source.py
+++ b/tests/test_view_source.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from pages.home_page import HomePage
 from pages.search_page import SearchPage
 from pages.library_editor_page import LibraryEditorPage


### PR DESCRIPTION
Adding a space between the license and the first import for readaility.
