### PR TITLE
Make gooder the pytest marks

### DIFF
--- a/tests/test_addon_count.py
+++ b/tests/test_addon_count.py
@@ -8,12 +8,11 @@ from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage
 from unittestzero import Assert
 import pytest
-prod = pytest.mark.prod
 
 
 class TestAddonCount:
 
-    @prod
+    @pytest.mark.nondestructive
     def test_addon_count(self, mozwebqa):
         #This test is to assert that the count of the addons on dashboard is equal to the number of addons present on the page.
         #Create page objects

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -8,12 +8,11 @@ from pages.home_page import HomePage
 from pages.dashboard_page import DashboardPage
 from unittestzero import Assert
 import pytest
-prod = pytest.mark.prod
 
 
 class TestHomepage:
 
-    @prod
+    @pytest.mark.nondestructive
     def test_doc_link_redirects(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
 
@@ -23,7 +22,7 @@ class TestHomepage:
 
         Assert.contains("https://addons.mozilla.org/en-US/developers/docs/sdk/latest/", homepage_obj.selenium.current_url)
 
-    @prod
+    @pytest.mark.nondestructive
     def test_addons_libraries_listed_on_home(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
 

--- a/tests/test_login_logout.py
+++ b/tests/test_login_logout.py
@@ -8,13 +8,12 @@ from pages.login_page import LoginPage
 from pages.dashboard_page import DashboardPage
 from unittestzero import Assert
 import pytest
-prod = pytest.mark.prod
 
 
 # These are login/logout tests with more detailed assertions intended for production runs
 class TestLoginLogout:
 
-    @prod
+    @pytest.mark.nondestructive
     def test_login(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         loginpage_obj = LoginPage(mozwebqa)
@@ -29,7 +28,7 @@ class TestLoginLogout:
         Assert.true(dashboard_obj.header.logged_in)
         Assert.equal(dashboard_obj.logged_in_username, mozwebqa.credentials['default']['name'])
 
-    @prod
+    @pytest.mark.nondestructive
     def test_logout(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         loginpage_obj = LoginPage(mozwebqa)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -12,12 +12,11 @@ from pages.library_editor_page import LibraryEditorPage
 from pages.user_page import UserPage
 from unittestzero import Assert
 import pytest
-xfail = pytest.mark.xfail
-prod = pytest.mark.prod
 
 
 class TestSearch:
 
+    @pytest.mark.native
     def test_search_by_addon_name_returns_addon(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         loginpage_obj = LoginPage(mozwebqa)
@@ -44,6 +43,7 @@ class TestSearch:
 
         searchpage_obj.delete_test_data()
 
+    @pytest.mark.native
     def test_search_by_library_name_returns_library(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         loginpage_obj = LoginPage(mozwebqa)
@@ -70,7 +70,7 @@ class TestSearch:
 
         searchpage_obj.delete_test_data()
 
-    @prod
+    @pytest.mark.nondestructive
     def test_search_partial_addon_name_returns_addon(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)
@@ -89,7 +89,7 @@ class TestSearch:
         Assert.true(searchpage_obj.addons_element_count() >= 1)
         Assert.true(searchpage_obj.addon(top_addon_name).is_displayed, 'Addon \'%s\' not found' % top_addon_name)
 
-    @prod
+    @pytest.mark.nondestructive
     def test_search_partial_library_name_returns_library(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)
@@ -108,7 +108,7 @@ class TestSearch:
         Assert.true(searchpage_obj.library_element_count() >= 1)
         Assert.true(searchpage_obj.library(top_library_name).is_displayed, 'Library \'%s\' not found' % top_library_name)
 
-    @prod
+    @pytest.mark.nondestructive
     def test_empty_search_returns_all_results(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)
@@ -126,7 +126,7 @@ class TestSearch:
         Assert.equal(searchpage_obj.addons_element_count(), 5)
         Assert.equal(searchpage_obj.library_element_count(), 5)
 
-    @prod
+    @pytest.mark.nondestructive
     def test_search_addon_filter_results_match(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)
@@ -148,7 +148,7 @@ class TestSearch:
 
         Assert.equal(label_count, element_count, 'Number of items displayed should match 20 or total number of results, whichever is smallest. This is due to pagination.')
 
-    @prod
+    @pytest.mark.nondestructive
     def test_search_library_filter_results_match(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)
@@ -170,7 +170,7 @@ class TestSearch:
 
         Assert.equal(label_count, element_count, 'Number of items displayed should match 20 or total number of results, whichever is smallest. This is due to pagination.')
 
-    @prod
+    @pytest.mark.nondestructive
     def test_clicking_addon_author_link_displays_author_profile(self, mozwebqa):
         # go to addon result and click author link
 
@@ -186,8 +186,7 @@ class TestSearch:
         searchpage_obj.addon(addon_name).click_author()
         Assert.equal(userpage_obj.author_name.lower(), author_name)
 
-    @xfail(reason="Bug 661619 - [traceback] MultipleObjectsReturned: get() returned more than one Profile -- it returned 2! Lookup parameters were {}")
-    @prod
+    @pytest.mark.nondestructive
     def test_clicking_library_author_link_displays_author_profile(self, mozwebqa):
 
         # go to library result and click author link
@@ -239,7 +238,8 @@ class TestSearch:
 
         searchpage_obj.delete_test_data()
 
-    @prod
+    @pytest.mark.native
+    @pytest.mark.nondestructive
     def test_copies_slider_filters_results(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)
@@ -254,7 +254,8 @@ class TestSearch:
         Assert.true(initial_addon_count > searchpage_obj.addons_count_label)
         Assert.true(initial_library_count > searchpage_obj.library_count_label)
 
-    @prod
+    @pytest.mark.native
+    @pytest.mark.nondestructive
     def test_used_packages_slider_filters_results(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)
@@ -268,7 +269,8 @@ class TestSearch:
 
         Assert.true(initial_library_count > searchpage_obj.library_count_label)
 
-    @prod
+    @pytest.mark.native
+    @pytest.mark.nondestructive
     def test_activity_slider_filters_results(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
         searchpage_obj = SearchPage(mozwebqa)

--- a/tests/test_view_source.py
+++ b/tests/test_view_source.py
@@ -38,6 +38,6 @@ class TestViewSource:
         homepage_obj.header.click_search()
         
         searchpage_obj.library(1).click()
-        
+
         Assert.true(libraryeditor_obj.tab(1).selected)
         Assert.not_none(libraryeditor_obj.tab(1).content)


### PR DESCRIPTION
Change/add pytest marks to be nondestructive/native.

Important: Before merging this pull request, change the flightdeck.prod job to use the '-k nondestructive' command line.
