### PR TITLE
Change teardown

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -29,15 +29,14 @@ class FlightDeckBasePage(Page):
 
     def delete_test_data(self):
         # use urllib so we can do all this stuff silently without selenium
-        session = self._get_session()
 
         # first loop through and delete all addon/libs added
         for i in self._garbage:
             delete_url = "%s/package/delete/%s/" % (self.base_url, i)
             try:
                 print "deleting %s" % delete_url
-                session.urlopen(delete_url)
-            except urllib2.HTTPError:
+                self.selenium.get(delete_url)
+            except:
                 # suppress any exceptions because we don't want the test to fail
                 print "Delete package %s failed" % i
 
@@ -104,22 +103,3 @@ class FlightDeckBasePage(Page):
             create_link = self.selenium.find_element(*self._create_locator)
             ActionChains(self.selenium).move_to_element_with_offset(create_link, 5, 5).perform()
             self.selenium.find_element_by_link_text("Library").click()
-
-    def _get_session(self, user="default"):
-        credentials = self.testsetup.credentials[user]
-        cookies = urllib2.HTTPCookieProcessor()
-        opener = urllib2.build_opener(cookies)
-        urllib2.install_opener(opener)
-
-        login_url = self.base_url + "/user/signin/"
-        urllib2.urlopen(login_url)
-
-        # we must open the login_url, collect the csrf token and then submit with login creds and the token
-        csrftoken = [x.value for x in cookies.cookiejar if x.name == 'csrftoken'][0]
-        form_data = urllib.urlencode({'username': credentials['email'], "password": credentials['password'], "csrfmiddlewaretoken": csrftoken})
-
-        req = urllib2.Request(login_url, form_data)
-        req.add_header('Referer', login_url)
-
-        urllib2.urlopen(req)
-        return urllib2


### PR DESCRIPTION
This changes the garbage collector/teardown to use the existing selenium session.

The urllib2 method was complicated by the move to using BrowserID.

This teardown retains the limitaiton that if the test fails then the teardown does not run but Automation team and I will work on a solution for that (which will aid this and other suites).
