### PR TITLE
Fix failing test due to increase number of addons

### DIFF
--- a/pages/dashboard_page.py
+++ b/pages/dashboard_page.py
@@ -49,11 +49,11 @@ class DashboardPage(FlightDeckBasePage):
         return DashboardPage(self.testsetup)
 
     @property
-    def is_next_button_disabled(self):
+    def is_next_button_enabled(self):
         return self.is_element_visible(*self._next_locator)
 
     @property
-    def is_previous_button_disabled(self):
+    def is_previous_button_enabled(self):
         return self.is_element_visible(*self._previous_locator)
 
     def click_public_addons_link(self):

--- a/tests/test_addon_count.py
+++ b/tests/test_addon_count.py
@@ -27,7 +27,7 @@ class TestAddonCount:
         #Get the number of addons that are displayed on the left hand side of the page.(Something like your add-ons(20))
         counter = dashboard_obj.addons_count_label
         addon_count = dashboard_obj.addons_element_count
-        while dashboard_obj.is_next_button_disabled:
+        while dashboard_obj.is_next_button_enabled:
             addon_count = addon_count + dashboard_obj.addons_element_count
             dashboard_obj = dashboard_obj.click_next()
 


### PR DESCRIPTION
Due to the fact that number of the addons has increased and only 10 add-ons are displayed at one time, i've modified the count method so that it treats this case.
