### PR TITLE
Xfailed TestHomepage.test_addons_libraries_listed_on_home

### DIFF
--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -21,6 +21,7 @@ class TestHomepage:
 
         Assert.contains("https://addons.mozilla.org/en-US/developers/docs/sdk/latest/", homepage_obj.selenium.current_url)
 
+    @pytest.mark.xfail(reason="Bug 806794 - [dev] Browse add-ons and Browse Libraries are not displayed on homepage")
     @pytest.mark.nondestructive
     def test_addons_libraries_listed_on_home(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=806794
[dev] Browse add-ons and Browse Libraries are not displayed on homepage
