### PR TITLE
Xfailed tests in test_search.py

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -36,7 +36,7 @@ class TestSearch:
 
         searchpage_obj.delete_test_data()
 
-    @pytest.mark.xfail(reason = "Bug 794432 - [dev]Searching for a library just created does not return the library when searching for it")
+    @pytest.mark.xfail(reason="Bug 794432 - [dev]Searching for a library just created does not return the library when searching for it")
     def test_search_by_library_name_returns_library(self, mozwebqa):
         homepage_obj = HomePage(mozwebqa)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=806438
[dev] 'No results were found for the term "".' on the base search page
