### PR TITLE
[dev]Xfail test_view_source_addon

### DIFF
--- a/tests/test_view_source.py
+++ b/tests/test_view_source.py
@@ -10,6 +10,7 @@ import pytest
 
 class TestViewSource:
 
+    @pytest.mark.xfail(reason='Bug 822250 - [dev] 500: Server Error is returned when clicking an add-on')
     @pytest.mark.nondestructive
     def test_view_source_addon(self, mozwebqa):
         #This test is to check viewing the source of an addon while not logged in


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=822250
[dev] 500: Server Error is returned when clicking an add-on
